### PR TITLE
To support HD520 on Ventura

### DIFF
--- a/EFI/OC/Config.plist
+++ b/EFI/OC/Config.plist
@@ -601,9 +601,9 @@
 				<key>@0,display-dual-link</key>
 				<integer>1</integer>
 				<key>AAPL,ig-platform-id</key>
-				<data>AAAWGQ==</data>
+				<data>AAAbWQ==</data>
 				<key>device-id</key>
-				<data>FhkAAA==</data>
+				<data>FlkAAA==</data>
 				<key>enable-hdmi20</key>
 				<data>AQAAAA==</data>
 				<key>force-online</key>


### PR DESCRIPTION
Permit to use the HW acceleration for display on Ventura.
So, Stage manager and visual effects can work with our major issues.
See https://elitemacx86.com/threads/how-to-enable-intel-skylake-graphics-intel-hd-graphics-515-520-530-540-550-and-580-on-macos-ventura-and-later.928/ for more informations.